### PR TITLE
csv separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - [loadDotEnv](#loaddotenv)
     - [multilineSep](#multilinesep)
     - [process](#process)
+    - [sep](#sep)
 - [Interface: GitBlame](#interface-gitblame)
   - [Hierarchy](#hierarchy)
   - [Properties](#properties-1)
@@ -68,6 +69,7 @@
     - [input](#input-1)
     - [loadDotEnv](#loaddotenv-1)
     - [multilineSep](#multilinesep-1)
+    - [sep](#sep-1)
   - [Functions](#functions)
     - [argsConfig](#argsconfig)
     - [csv](#csv)
@@ -112,7 +114,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:27](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L27)
+[types.d.ts:27](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L27)
 
 ---
 
@@ -122,7 +124,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:26](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L26)
+[types.d.ts:26](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L26)
 
 ---
 
@@ -132,7 +134,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:28](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L28)
+[types.d.ts:28](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L28)
 
 ---
 
@@ -142,7 +144,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L29)
+[types.d.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L29)
 
 ---
 
@@ -152,7 +154,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:30](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L30)
+[types.d.ts:30](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L30)
 
 ---
 
@@ -162,7 +164,17 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:31](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L31)
+[types.d.ts:32](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L32)
+
+---
+
+### sep
+
+• **sep**: `string`
+
+#### Defined in
+
+[types.d.ts:31](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L31)
 
 <a name="interfacesgitblamemd"></a>
 
@@ -184,7 +196,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L42)
+[types.d.ts:43](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L43)
 
 ---
 
@@ -194,7 +206,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:43](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L43)
+[types.d.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L44)
 
 ---
 
@@ -204,7 +216,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L44)
+[types.d.ts:45](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L45)
 
 ---
 
@@ -214,7 +226,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:45](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L45)
+[types.d.ts:46](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L46)
 
 ---
 
@@ -224,7 +236,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:46](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L46)
+[types.d.ts:47](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L47)
 
 ---
 
@@ -234,7 +246,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:47](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L47)
+[types.d.ts:48](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L48)
 
 ---
 
@@ -244,7 +256,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:48](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L48)
+[types.d.ts:49](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L49)
 
 ---
 
@@ -254,7 +266,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:49](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L49)
+[types.d.ts:50](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L50)
 
 ---
 
@@ -264,7 +276,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:39](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L39)
+[types.d.ts:40](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L40)
 
 ---
 
@@ -274,7 +286,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:40](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L40)
+[types.d.ts:41](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L41)
 
 ---
 
@@ -284,7 +296,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:38](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L38)
+[types.d.ts:39](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L39)
 
 ---
 
@@ -294,7 +306,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:41](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L41)
+[types.d.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L42)
 
 ---
 
@@ -304,7 +316,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:50](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L50)
+[types.d.ts:51](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L51)
 
 <a name="interfacesgitmergemd"></a>
 
@@ -330,7 +342,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L42)
+[types.d.ts:43](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L43)
 
 ---
 
@@ -344,7 +356,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:43](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L43)
+[types.d.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L44)
 
 ---
 
@@ -358,7 +370,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L44)
+[types.d.ts:45](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L45)
 
 ---
 
@@ -372,7 +384,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:45](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L45)
+[types.d.ts:46](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L46)
 
 ---
 
@@ -382,7 +394,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:56](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L56)
+[types.d.ts:57](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L57)
 
 ---
 
@@ -396,7 +408,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:46](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L46)
+[types.d.ts:47](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L47)
 
 ---
 
@@ -410,7 +422,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:47](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L47)
+[types.d.ts:48](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L48)
 
 ---
 
@@ -424,7 +436,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:48](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L48)
+[types.d.ts:49](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L49)
 
 ---
 
@@ -438,7 +450,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:49](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L49)
+[types.d.ts:50](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L50)
 
 ---
 
@@ -452,7 +464,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:39](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L39)
+[types.d.ts:40](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L40)
 
 ---
 
@@ -466,7 +478,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:40](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L40)
+[types.d.ts:41](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L41)
 
 ---
 
@@ -476,7 +488,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:54](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L54)
+[types.d.ts:55](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L55)
 
 ---
 
@@ -486,7 +498,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:55](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L55)
+[types.d.ts:56](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L56)
 
 ---
 
@@ -500,7 +512,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:38](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L38)
+[types.d.ts:39](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L39)
 
 ---
 
@@ -514,7 +526,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:41](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L41)
+[types.d.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L42)
 
 ---
 
@@ -528,7 +540,7 @@ A single line parsed git blame
 
 #### Defined in
 
-[types.d.ts:50](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L50)
+[types.d.ts:51](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L51)
 
 <a name="interfacesmatchmd"></a>
 
@@ -544,7 +556,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:13](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L13)
+[types.d.ts:13](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L13)
 
 ---
 
@@ -554,7 +566,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:12](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L12)
+[types.d.ts:12](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L12)
 
 ---
 
@@ -564,7 +576,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:11](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L11)
+[types.d.ts:11](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L11)
 
 ---
 
@@ -574,7 +586,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:6](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L6)
+[types.d.ts:6](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L6)
 
 ---
 
@@ -584,7 +596,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:18](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L18)
+[types.d.ts:18](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L18)
 
 ---
 
@@ -594,7 +606,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:14](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L14)
+[types.d.ts:14](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L14)
 
 ---
 
@@ -604,7 +616,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:10](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L10)
+[types.d.ts:10](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L10)
 
 ---
 
@@ -614,7 +626,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:15](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L15)
+[types.d.ts:15](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L15)
 
 ---
 
@@ -624,7 +636,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:9](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L9)
+[types.d.ts:9](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L9)
 
 ---
 
@@ -634,7 +646,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:19](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L19)
+[types.d.ts:19](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L19)
 
 ---
 
@@ -644,7 +656,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 #### Defined in
 
-[types.d.ts:7](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/types.d.ts#L7)
+[types.d.ts:7](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/types.d.ts#L7)
 
 <a name="modulesmd"></a>
 
@@ -667,7 +679,7 @@ Assign a name, primarily to use for env variable prefix
 
 #### Defined in
 
-[config.ts:17](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L17)
+[config.ts:17](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L17)
 
 ---
 
@@ -683,7 +695,7 @@ Assign a name, primarily to use for env variable prefix
 
 #### Defined in
 
-[index.ts:11](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/index.ts#L11)
+[index.ts:11](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/index.ts#L11)
 
 ---
 
@@ -695,7 +707,7 @@ For reference, a copy of the startup defaults
 
 #### Defined in
 
-[config.ts:45](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L45)
+[config.ts:50](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L50)
 
 ---
 
@@ -707,7 +719,7 @@ Source to read. Defaults to `-` for stdin.
 
 #### Defined in
 
-[config.ts:21](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L21)
+[config.ts:21](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L21)
 
 ---
 
@@ -719,7 +731,7 @@ Whether to load dotenv or a function to load it
 
 #### Defined in
 
-[config.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L25)
+[config.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L25)
 
 ---
 
@@ -731,7 +743,19 @@ Seperator for multi-line code blocks
 
 #### Defined in
 
-[config.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L29)
+[config.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L29)
+
+---
+
+### sep
+
+• **sep**: `string` = `"\t"`
+
+Separator for output csv
+
+#### Defined in
+
+[config.ts:33](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L33)
 
 ## Functions
 
@@ -754,7 +778,7 @@ Get config from args & env
 
 #### Defined in
 
-[config.ts:74](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L74)
+[config.ts:79](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L79)
 
 ---
 
@@ -774,7 +798,7 @@ Get config from args & env
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/streams.ts#L44)
 
 ---
 
@@ -796,7 +820,7 @@ Populate a Config with defaults.
 
 #### Defined in
 
-[config.ts:34](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L34)
+[config.ts:38](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L38)
 
 ---
 
@@ -816,7 +840,7 @@ Populate a Config with defaults.
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/streams.ts#L44)
 
 ---
 
@@ -836,7 +860,7 @@ Populate a Config with defaults.
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/streams.ts#L44)
 
 ---
 
@@ -856,7 +880,7 @@ Populate a Config with defaults.
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/streams.ts#L44)
 
 ---
 
@@ -879,7 +903,7 @@ Process an async-iterator of strings, splitting it on newlines
 
 #### Defined in
 
-[lines.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/lines.ts#L8)
+[lines.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/lines.ts#L8)
 
 ---
 
@@ -895,7 +919,7 @@ Default strategy to load dotenv first time only.
 
 #### Defined in
 
-[config.ts:65](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L65)
+[config.ts:70](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L70)
 
 ---
 
@@ -918,7 +942,7 @@ Or pass through if no multilineSep configured
 
 #### Defined in
 
-[group.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/group.ts#L8)
+[group.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/group.ts#L8)
 
 ---
 
@@ -950,7 +974,7 @@ Or pass through if no multilineSep configured
 
 #### Defined in
 
-[parse.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/parse.ts#L25)
+[parse.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/parse.ts#L25)
 
 ---
 
@@ -971,7 +995,7 @@ Or pass through if no multilineSep configured
 
 #### Defined in
 
-[config.ts:111](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L111)
+[config.ts:123](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L123)
 
 ---
 
@@ -988,7 +1012,7 @@ Can be useful if config might change & wants freshened.
 
 #### Defined in
 
-[config.ts:56](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/config.ts#L56)
+[config.ts:61](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/config.ts#L61)
 
 ---
 
@@ -1008,7 +1032,7 @@ Can be useful if config might change & wants freshened.
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/streams.ts#L44)
 
 ---
 
@@ -1028,4 +1052,4 @@ Can be useful if config might change & wants freshened.
 
 #### Defined in
 
-[lines.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/2341bce/lines.ts#L42)
+[lines.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/09af281/lines.ts#L42)

--- a/config.ts
+++ b/config.ts
@@ -27,6 +27,10 @@ export let loadDotEnv: boolean | Function = () => loadDotEnvOnce;
  * Seperator for multi-line code blocks
  */
 export let multilineSep: string = "";
+/**
+ * Separator for output csv
+ */
+export let sep = "\t";
 
 /**
  * Populate a Config with defaults.
@@ -35,6 +39,7 @@ export const defaults = (base?: Partial<Config>): Config => ({
   appName,
   appEnv: (base?.appName || appName).toLowerCase(),
   input,
+  sep,
   multilineSep,
   ...base,
 });
@@ -99,10 +104,17 @@ export const argsConfig = (
     .default(config)
     .option("input", {
       alias: "i",
+      description: "input file, or - for stdin",
       nargs: 1,
     })
     .option("multilineSep", {
       alias: ["multisep", "s"],
+      description: "optional multiline separator used in input",
+      nargs: 1,
+    })
+    .option("sep", {
+      alias: "S",
+      description: "csv output separator",
       nargs: 1,
     });
   return computed.argv as unknown as Config;

--- a/csv.ts
+++ b/csv.ts
@@ -1,7 +1,7 @@
 import { itMap } from "./streams.js";
-import { Match } from "./types.js";
+import { Config, Match } from "./types.js";
 
-function writeCsv(m: Partial<Match>) {
+const writeCsv = (c: Config) => (m: Partial<Match>) => {
   let output = [
     m.project,
     m.path,
@@ -12,7 +12,7 @@ function writeCsv(m: Partial<Match>) {
     m.pr,
     m.text,
   ];
-  return output.join("\t");
+  return output.join();
 }
-export const csv = itMap(writeCsv);
+export const csv = (c: Config) => itMap(writeCsv(c));
 export default csv;

--- a/main.ts
+++ b/main.ts
@@ -33,7 +33,7 @@ export function main(c: Config = config(process.argv, { process })) {
     gitProject,
     gitBlame,
     githubPr,
-    csv
+    csv(c)
   );
 }
 export default main;

--- a/types.d.ts
+++ b/types.d.ts
@@ -28,6 +28,7 @@ export interface Config {
   input?: ReadInput;
   loadDotEnv?: boolean | Function;
   multilineSep?: string | RegExp | null;
+  sep: string;
   process?: Process;
 }
 


### PR DESCRIPTION
Allow output csv separator to be configurable with `-S`.

Very useful for debugging where \t is ugly.