### PR TITLE
docs: add docs to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,26 +28,35 @@
     - [previous](#previous)
     - [rev](#rev)
     - [summary](#summary)
-- [Interface: GitMerge](#interface-gitmerge)
+- [Interface: GitBlameBase](#interface-gitblamebase)
   - [Hierarchy](#hierarchy-1)
   - [Properties](#properties-2)
     - [author](#author-1)
     - [authorEmail](#authoremail-1)
     - [authorTime](#authortime-1)
-    - [authorTz](#authortz-1)
-    - [branch](#branch)
     - [committer](#committer-1)
     - [committerEmail](#committeremail-1)
     - [committerTime](#committertime-1)
-    - [committerTz](#committertz-1)
-    - [lines](#lines-1)
-    - [parent](#parent)
-    - [pr](#pr)
     - [previous](#previous-1)
     - [rev](#rev-1)
     - [summary](#summary-1)
-- [Interface: Match](#interface-match)
+- [Interface: GitMerge](#interface-gitmerge)
+  - [Hierarchy](#hierarchy-2)
   - [Properties](#properties-3)
+    - [author](#author-2)
+    - [authorEmail](#authoremail-2)
+    - [authorTime](#authortime-2)
+    - [branch](#branch)
+    - [committer](#committer-2)
+    - [committerEmail](#committeremail-2)
+    - [committerTime](#committertime-2)
+    - [parent](#parent)
+    - [pr](#pr)
+    - [previous](#previous-2)
+    - [rev](#rev-2)
+    - [summary](#summary-2)
+- [Interface: Match](#interface-match)
+  - [Properties](#properties-4)
     - [commits](#commits)
     - [head](#head)
     - [lineEnd](#lineend)
@@ -81,7 +90,7 @@
     - [gitHead](#githead)
     - [gitProject](#gitproject)
     - [githubPr](#githubpr)
-    - [lines](#lines-2)
+    - [lines](#lines-1)
     - [loadDotEnvOnce](#loaddotenvonce)
     - [multilineGroup](#multilinegroup)
     - [parse](#parse)
@@ -120,7 +129,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:28](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L28)
+[types.d.ts:64](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L64)
 
 ---
 
@@ -130,7 +139,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:27](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L27)
+[types.d.ts:63](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L63)
 
 ---
 
@@ -140,7 +149,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L29)
+[types.d.ts:65](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L65)
 
 ---
 
@@ -150,7 +159,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:30](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L30)
+[types.d.ts:66](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L66)
 
 ---
 
@@ -160,7 +169,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:31](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L31)
+[types.d.ts:67](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L67)
 
 ---
 
@@ -170,7 +179,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:34](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L34)
+[types.d.ts:70](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L70)
 
 ---
 
@@ -180,7 +189,7 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:32](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L32)
+[types.d.ts:68](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L68)
 
 ---
 
@@ -190,17 +199,211 @@ Configuration for a run
 
 #### Defined in
 
-[types.d.ts:33](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L33)
+[types.d.ts:69](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L69)
 
 <a name="interfacesgitblamemd"></a>
 
 # Interface: GitBlame
 
-A single line parsed git blame
+A single commit & single file's parsed Git Blame
 
 ## Hierarchy
 
-- **`GitBlame`**
+- [`GitBlameBase`](#interfacesgitblamebasemd)
+
+  ↳ **`GitBlame`**
+
+## Properties
+
+### author
+
+• **author**: `string`
+
+Git author of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[author](#author)
+
+#### Defined in
+
+[types.d.ts:84](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L84)
+
+---
+
+### authorEmail
+
+• **authorEmail**: `string`
+
+Git author email of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[authorEmail](#authoremail)
+
+#### Defined in
+
+[types.d.ts:88](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L88)
+
+---
+
+### authorTime
+
+• **authorTime**: `Date`
+
+Author time of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[authorTime](#authortime)
+
+#### Defined in
+
+[types.d.ts:92](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L92)
+
+---
+
+### authorTz
+
+• `Optional` **authorTz**: `number`
+
+Timezone of author date
+
+#### Defined in
+
+[types.d.ts:122](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L122)
+
+---
+
+### committer
+
+• **committer**: `string`
+
+Committer name of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[committer](#committer)
+
+#### Defined in
+
+[types.d.ts:96](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L96)
+
+---
+
+### committerEmail
+
+• **committerEmail**: `string`
+
+Committer email of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[committerEmail](#committeremail)
+
+#### Defined in
+
+[types.d.ts:100](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L100)
+
+---
+
+### committerTime
+
+• **committerTime**: `Date`
+
+Committer time of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[committerTime](#committertime)
+
+#### Defined in
+
+[types.d.ts:104](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L104)
+
+---
+
+### committerTz
+
+• `Optional` **committerTz**: `number`
+
+Timezone of committer date
+
+#### Defined in
+
+[types.d.ts:126](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L126)
+
+---
+
+### lines
+
+• `Optional` **lines**: `number`[]
+
+Lines of file this blame applies to
+
+#### Defined in
+
+[types.d.ts:130](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L130)
+
+---
+
+### previous
+
+• `Optional` **previous**: `string`
+
+Previous sha of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[previous](#previous)
+
+#### Defined in
+
+[types.d.ts:108](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L108)
+
+---
+
+### rev
+
+• **rev**: `string`
+
+revision-sha of this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[rev](#rev)
+
+#### Defined in
+
+[types.d.ts:80](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L80)
+
+---
+
+### summary
+
+• **summary**: `string`
+
+Summary text for this blame.
+
+#### Inherited from
+
+[GitBlameBase](#interfacesgitblamebasemd).[summary](#summary)
+
+#### Defined in
+
+[types.d.ts:112](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L112)
+
+<a name="interfacesgitblamebasemd"></a>
+
+# Interface: GitBlameBase
+
+Common "blame" information shared by either a line-by-line style git-blame, or by a merge commit.
+
+## Hierarchy
+
+- **`GitBlameBase`**
+
+  ↳ [`GitBlame`](#interfacesgitblamemd)
 
   ↳ [`GitMerge`](#interfacesgitmergemd)
 
@@ -210,9 +413,11 @@ A single line parsed git blame
 
 • **author**: `string`
 
+Git author of this blame.
+
 #### Defined in
 
-[types.d.ts:43](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L43)
+[types.d.ts:84](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L84)
 
 ---
 
@@ -220,9 +425,11 @@ A single line parsed git blame
 
 • **authorEmail**: `string`
 
+Git author email of this blame.
+
 #### Defined in
 
-[types.d.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L44)
+[types.d.ts:88](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L88)
 
 ---
 
@@ -230,19 +437,11 @@ A single line parsed git blame
 
 • **authorTime**: `Date`
 
-#### Defined in
-
-[types.d.ts:45](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L45)
-
----
-
-### authorTz
-
-• `Optional` **authorTz**: `number`
+Author time of this blame.
 
 #### Defined in
 
-[types.d.ts:46](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L46)
+[types.d.ts:92](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L92)
 
 ---
 
@@ -250,9 +449,11 @@ A single line parsed git blame
 
 • **committer**: `string`
 
+Committer name of this blame.
+
 #### Defined in
 
-[types.d.ts:47](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L47)
+[types.d.ts:96](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L96)
 
 ---
 
@@ -260,9 +461,11 @@ A single line parsed git blame
 
 • **committerEmail**: `string`
 
+Committer email of this blame.
+
 #### Defined in
 
-[types.d.ts:48](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L48)
+[types.d.ts:100](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L100)
 
 ---
 
@@ -270,29 +473,11 @@ A single line parsed git blame
 
 • **committerTime**: `Date`
 
-#### Defined in
-
-[types.d.ts:49](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L49)
-
----
-
-### committerTz
-
-• `Optional` **committerTz**: `number`
+Committer time of this blame.
 
 #### Defined in
 
-[types.d.ts:50](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L50)
-
----
-
-### lines
-
-• `Optional` **lines**: `number`[]
-
-#### Defined in
-
-[types.d.ts:53](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L53)
+[types.d.ts:104](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L104)
 
 ---
 
@@ -300,9 +485,11 @@ A single line parsed git blame
 
 • `Optional` **previous**: `string`
 
+Previous sha of this blame.
+
 #### Defined in
 
-[types.d.ts:51](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L51)
+[types.d.ts:108](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L108)
 
 ---
 
@@ -310,9 +497,11 @@ A single line parsed git blame
 
 • **rev**: `string`
 
+revision-sha of this blame.
+
 #### Defined in
 
-[types.d.ts:41](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L41)
+[types.d.ts:80](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L80)
 
 ---
 
@@ -320,19 +509,21 @@ A single line parsed git blame
 
 • **summary**: `string`
 
+Summary text for this blame.
+
 #### Defined in
 
-[types.d.ts:52](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L52)
+[types.d.ts:112](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L112)
 
 <a name="interfacesgitmergemd"></a>
 
 # Interface: GitMerge
 
-A single line parsed git blame
+Blame information for a git merge, typically parsed from Github format PR messages.
 
 ## Hierarchy
 
-- [`GitBlame`](#interfacesgitblamemd)
+- [`GitBlameBase`](#interfacesgitblamebasemd)
 
   ↳ **`GitMerge`**
 
@@ -342,13 +533,15 @@ A single line parsed git blame
 
 • **author**: `string`
 
+Git author of this blame.
+
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[author](#author)
+[GitBlameBase](#interfacesgitblamebasemd).[author](#author)
 
 #### Defined in
 
-[types.d.ts:43](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L43)
+[types.d.ts:84](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L84)
 
 ---
 
@@ -356,13 +549,15 @@ A single line parsed git blame
 
 • **authorEmail**: `string`
 
+Git author email of this blame.
+
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[authorEmail](#authoremail)
+[GitBlameBase](#interfacesgitblamebasemd).[authorEmail](#authoremail)
 
 #### Defined in
 
-[types.d.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L44)
+[types.d.ts:88](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L88)
 
 ---
 
@@ -370,27 +565,15 @@ A single line parsed git blame
 
 • **authorTime**: `Date`
 
-#### Inherited from
-
-[GitBlame](#interfacesgitblamemd).[authorTime](#authortime)
-
-#### Defined in
-
-[types.d.ts:45](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L45)
-
----
-
-### authorTz
-
-• `Optional` **authorTz**: `number`
+Author time of this blame.
 
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[authorTz](#authortz)
+[GitBlameBase](#interfacesgitblamebasemd).[authorTime](#authortime)
 
 #### Defined in
 
-[types.d.ts:46](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L46)
+[types.d.ts:92](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L92)
 
 ---
 
@@ -398,9 +581,11 @@ A single line parsed git blame
 
 • `Optional` **branch**: `string`
 
+Branch name, parsed from summary.
+
 #### Defined in
 
-[types.d.ts:59](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L59)
+[types.d.ts:148](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L148)
 
 ---
 
@@ -408,13 +593,15 @@ A single line parsed git blame
 
 • **committer**: `string`
 
+Committer name of this blame.
+
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[committer](#committer)
+[GitBlameBase](#interfacesgitblamebasemd).[committer](#committer)
 
 #### Defined in
 
-[types.d.ts:47](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L47)
+[types.d.ts:96](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L96)
 
 ---
 
@@ -422,13 +609,15 @@ A single line parsed git blame
 
 • **committerEmail**: `string`
 
+Committer email of this blame.
+
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[committerEmail](#committeremail)
+[GitBlameBase](#interfacesgitblamebasemd).[committerEmail](#committeremail)
 
 #### Defined in
 
-[types.d.ts:48](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L48)
+[types.d.ts:100](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L100)
 
 ---
 
@@ -436,41 +625,15 @@ A single line parsed git blame
 
 • **committerTime**: `Date`
 
-#### Inherited from
-
-[GitBlame](#interfacesgitblamemd).[committerTime](#committertime)
-
-#### Defined in
-
-[types.d.ts:49](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L49)
-
----
-
-### committerTz
-
-• `Optional` **committerTz**: `number`
+Committer time of this blame.
 
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[committerTz](#committertz)
+[GitBlameBase](#interfacesgitblamebasemd).[committerTime](#committertime)
 
 #### Defined in
 
-[types.d.ts:50](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L50)
-
----
-
-### lines
-
-• `Optional` **lines**: `number`[]
-
-#### Inherited from
-
-[GitBlame](#interfacesgitblamemd).[lines](#lines)
-
-#### Defined in
-
-[types.d.ts:53](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L53)
+[types.d.ts:104](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L104)
 
 ---
 
@@ -478,9 +641,11 @@ A single line parsed git blame
 
 • **parent**: `string`[]
 
+The parent commits for this merge
+
 #### Defined in
 
-[types.d.ts:57](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L57)
+[types.d.ts:140](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L140)
 
 ---
 
@@ -488,9 +653,11 @@ A single line parsed git blame
 
 • `Optional` **pr**: `number`
 
+Pull request number, parsed from summary.
+
 #### Defined in
 
-[types.d.ts:58](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L58)
+[types.d.ts:144](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L144)
 
 ---
 
@@ -498,13 +665,15 @@ A single line parsed git blame
 
 • `Optional` **previous**: `string`
 
+Previous sha of this blame.
+
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[previous](#previous)
+[GitBlameBase](#interfacesgitblamebasemd).[previous](#previous)
 
 #### Defined in
 
-[types.d.ts:51](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L51)
+[types.d.ts:108](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L108)
 
 ---
 
@@ -512,13 +681,15 @@ A single line parsed git blame
 
 • **rev**: `string`
 
+revision-sha of this blame.
+
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[rev](#rev)
+[GitBlameBase](#interfacesgitblamebasemd).[rev](#rev)
 
 #### Defined in
 
-[types.d.ts:41](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L41)
+[types.d.ts:80](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L80)
 
 ---
 
@@ -526,13 +697,15 @@ A single line parsed git blame
 
 • **summary**: `string`
 
+Summary text for this blame.
+
 #### Inherited from
 
-[GitBlame](#interfacesgitblamemd).[summary](#summary)
+[GitBlameBase](#interfacesgitblamebasemd).[summary](#summary)
 
 #### Defined in
 
-[types.d.ts:52](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L52)
+[types.d.ts:112](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L112)
 
 <a name="interfacesmatchmd"></a>
 
@@ -546,9 +719,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • `Optional` **commits**: `Record`<`string`, [`GitBlame`](#interfacesgitblamemd)\>
 
+All commits found for this match, by sha.
+
 #### Defined in
 
-[types.d.ts:13](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L13)
+[types.d.ts:34](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L34)
 
 ---
 
@@ -556,9 +731,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **head**: `string`
 
+Current rev this project is on.
+
 #### Defined in
 
-[types.d.ts:16](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L16)
+[types.d.ts:46](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L46)
 
 ---
 
@@ -566,9 +743,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **lineEnd**: `number`
 
+Line where this match ends.
+
 #### Defined in
 
-[types.d.ts:12](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L12)
+[types.d.ts:30](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L30)
 
 ---
 
@@ -576,9 +755,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **lineStart**: `number`
 
+Line where this match starts.
+
 #### Defined in
 
-[types.d.ts:11](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L11)
+[types.d.ts:26](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L26)
 
 ---
 
@@ -586,9 +767,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **matchedPath**: `string`
 
+Path that grep found for this match.
+
 #### Defined in
 
-[types.d.ts:6](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L6)
+[types.d.ts:9](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L9)
 
 ---
 
@@ -596,9 +779,12 @@ A grep match. Listed vaguely in order of display in csv,
 
 • `Optional` **matches**: `number`[]
 
+List of exact line numbers where there is a match.
+Since lineStart & lineEnd might include --before, --after, --context grep context.
+
 #### Defined in
 
-[types.d.ts:19](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L19)
+[types.d.ts:52](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L52)
 
 ---
 
@@ -606,9 +792,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • `Optional` **merges**: `Record`<`string`, [`GitMerge`](#interfacesgitmergemd)\>
 
+All prs found for this match, by sha.
+
 #### Defined in
 
-[types.d.ts:14](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L14)
+[types.d.ts:38](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L38)
 
 ---
 
@@ -616,9 +804,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **path**: `string`
 
+Path of file inside the project for this match.
+
 #### Defined in
 
-[types.d.ts:10](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L10)
+[types.d.ts:22](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L22)
 
 ---
 
@@ -626,9 +816,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **project**: `string`
 
+Project directory name for this match.
+
 #### Defined in
 
-[types.d.ts:9](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L9)
+[types.d.ts:18](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L18)
 
 ---
 
@@ -636,9 +828,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **rootDir**: `string`
 
+Directory where we found this project
+
 #### Defined in
 
-[types.d.ts:20](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L20)
+[types.d.ts:56](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L56)
 
 ---
 
@@ -646,9 +840,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • **text**: `string`
 
+Text of this match.
+
 #### Defined in
 
-[types.d.ts:7](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L7)
+[types.d.ts:13](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L13)
 
 ---
 
@@ -656,9 +852,11 @@ A grep match. Listed vaguely in order of display in csv,
 
 • `Optional` **vars**: `Record`<`string`, `string`\>
 
+Any free-variables captured by semgrep.
+
 #### Defined in
 
-[types.d.ts:15](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/types.d.ts#L15)
+[types.d.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/types.d.ts#L42)
 
 <a name="modulesmd"></a>
 
@@ -668,6 +866,7 @@ A grep match. Listed vaguely in order of display in csv,
 
 - [Config](#interfacesconfigmd)
 - [GitBlame](#interfacesgitblamemd)
+- [GitBlameBase](#interfacesgitblamebasemd)
 - [GitMerge](#interfacesgitmergemd)
 - [Match](#interfacesmatchmd)
 
@@ -681,7 +880,7 @@ Assign a name, primarily to use for env variable prefix
 
 #### Defined in
 
-[config.ts:17](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L17)
+[config.ts:17](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L17)
 
 ---
 
@@ -691,7 +890,7 @@ Assign a name, primarily to use for env variable prefix
 
 #### Defined in
 
-[csv.ts:12](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/csv.ts#L12)
+[csv.ts:12](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/csv.ts#L12)
 
 ---
 
@@ -707,7 +906,7 @@ Assign a name, primarily to use for env variable prefix
 
 #### Defined in
 
-[index.ts:11](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/index.ts#L11)
+[index.ts:11](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/index.ts#L11)
 
 ---
 
@@ -719,7 +918,7 @@ For reference, a copy of the startup defaults
 
 #### Defined in
 
-[config.ts:55](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L55)
+[config.ts:55](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L55)
 
 ---
 
@@ -731,7 +930,7 @@ Source to read. Defaults to `-` for stdin.
 
 #### Defined in
 
-[config.ts:21](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L21)
+[config.ts:21](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L21)
 
 ---
 
@@ -743,7 +942,7 @@ Whether to load dotenv or a function to load it
 
 #### Defined in
 
-[config.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L25)
+[config.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L25)
 
 ---
 
@@ -755,7 +954,7 @@ Seperator for multi-line code blocks
 
 #### Defined in
 
-[config.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L29)
+[config.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L29)
 
 ---
 
@@ -767,7 +966,7 @@ Expect semgrep json input
 
 #### Defined in
 
-[config.ts:33](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L33)
+[config.ts:33](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L33)
 
 ---
 
@@ -779,7 +978,7 @@ Separator for output csv
 
 #### Defined in
 
-[config.ts:37](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L37)
+[config.ts:37](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L37)
 
 ## Functions
 
@@ -802,7 +1001,7 @@ Get config from args & env
 
 #### Defined in
 
-[config.ts:84](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L84)
+[config.ts:84](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L84)
 
 ---
 
@@ -834,7 +1033,7 @@ Get config from args & env
 
 #### Defined in
 
-[csv.ts:94](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/csv.ts#L94)
+[csv.ts:94](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/csv.ts#L94)
 
 ---
 
@@ -866,7 +1065,7 @@ Get config from args & env
 
 #### Defined in
 
-[csv.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/csv.ts#L29)
+[csv.ts:29](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/csv.ts#L29)
 
 ---
 
@@ -888,7 +1087,7 @@ Populate a Config with defaults.
 
 #### Defined in
 
-[config.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L42)
+[config.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L42)
 
 ---
 
@@ -908,7 +1107,7 @@ Populate a Config with defaults.
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/streams.ts#L44)
 
 ---
 
@@ -936,7 +1135,7 @@ Attach the sha of main branch
 
 #### Defined in
 
-[git.ts:229](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/git.ts#L229)
+[git.ts:229](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/git.ts#L229)
 
 ---
 
@@ -956,7 +1155,7 @@ Attach the sha of main branch
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/streams.ts#L44)
 
 ---
 
@@ -976,7 +1175,7 @@ Attach the sha of main branch
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/streams.ts#L44)
 
 ---
 
@@ -999,7 +1198,7 @@ Process an async-iterator of strings, splitting it on newlines
 
 #### Defined in
 
-[lines.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/lines.ts#L8)
+[lines.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/lines.ts#L8)
 
 ---
 
@@ -1015,7 +1214,7 @@ Default strategy to load dotenv first time only.
 
 #### Defined in
 
-[config.ts:75](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L75)
+[config.ts:75](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L75)
 
 ---
 
@@ -1038,7 +1237,7 @@ Or pass through if no multilineSep configured
 
 #### Defined in
 
-[group.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/group.ts#L8)
+[group.ts:8](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/group.ts#L8)
 
 ---
 
@@ -1070,7 +1269,7 @@ Or pass through if no multilineSep configured
 
 #### Defined in
 
-[parse.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/parse.ts#L25)
+[parse.ts:25](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/parse.ts#L25)
 
 ---
 
@@ -1090,7 +1289,7 @@ Or pass through if no multilineSep configured
 
 #### Defined in
 
-[parse.ts:119](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/parse.ts#L119)
+[parse.ts:119](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/parse.ts#L119)
 
 ---
 
@@ -1112,7 +1311,7 @@ Parse semgrep json input lines
 
 #### Defined in
 
-[parse.ts:88](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/parse.ts#L88)
+[parse.ts:88](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/parse.ts#L88)
 
 ---
 
@@ -1133,7 +1332,7 @@ Parse semgrep json input lines
 
 #### Defined in
 
-[config.ts:134](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L134)
+[config.ts:134](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L134)
 
 ---
 
@@ -1150,7 +1349,7 @@ Can be useful if config might change & wants freshened.
 
 #### Defined in
 
-[config.ts:66](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/config.ts#L66)
+[config.ts:66](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/config.ts#L66)
 
 ---
 
@@ -1170,7 +1369,7 @@ Can be useful if config might change & wants freshened.
 
 #### Defined in
 
-[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/streams.ts#L44)
+[streams.ts:44](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/streams.ts#L44)
 
 ---
 
@@ -1190,4 +1389,4 @@ Can be useful if config might change & wants freshened.
 
 #### Defined in
 
-[lines.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/8e6297f/lines.ts#L42)
+[lines.ts:42](https://github.com/pinko-fowle/gitgrep2csv/blob/5ebd54d/lines.ts#L42)

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,20 +3,56 @@
  */
 export interface Match {
   // input data
+  /**
+  * Path that grep found for this match.
+  */
   matchedPath: string; // not printed
+  /**
+  * Text of this match.
+  */
   text: string; // displayed last in csv
 
+  /**
+  * Project directory name for this match.
+  */
   project: string;
+  /**
+  * Path of file inside the project for this match.
+  */
   path: string;
+  /**
+  * Line where this match starts.
+  */
   lineStart: number;
+  /**
+  * Line where this match ends.
+  */
   lineEnd: number;
+  /**
+  * All commits found for this match, by sha.
+  */
   commits?: Record<string, GitBlame>; // rev->blame
+  /**
+  * All prs found for this match, by sha.
+  */
   merges?: Record<string, GitMerge>; // rev->merge
+  /**
+  * Any free-variables captured by semgrep.
+  */
   vars?: Record<string, string>; // semgrep can capture variables for us
+  /**
+  * Current rev this project is on.
+  */
   head: string; // rev that head is on
 
-  // not displayed
+  /**
+  * List of exact line numbers where there is a match.
+  * Since lineStart & lineEnd might include --before, --after, --context grep context.
+  */
   matches?: number[]; // unused for now
+  /**
+  * Directory where we found this project
+  */
   rootDir: string; // directory for project
 }
 
@@ -35,26 +71,79 @@ export interface Config {
 }
 
 /**
- * A single line parsed git blame
+ * Common "blame" information shared by either a line-by-line style git-blame, or by a merge commit.
  */
-export interface GitBlame {
+export interface GitBlameBase {
+  /**
+  * revision-sha of this blame.
+  */
   rev: string;
-  //subsequent?: number; // blame only
+  /**
+  * Git author of this blame.
+  */
   author: string;
+  /**
+  * Git author email of this blame.
+  */
   authorEmail: string;
+  /**
+  * Author time of this blame.
+  */
   authorTime: Date;
-  authorTz?: number; // blame only
+  /**
+  * Committer name of this blame.
+  */
   committer: string;
+  /**
+  * Committer email of this blame.
+  */
   committerEmail: string;
+  /**
+  * Committer time of this blame.
+  */
   committerTime: Date;
-  committerTz?: number; // blame only
+  /**
+  * Previous sha of this blame.
+  */
   previous?: string; // TODO: merge
+  /**
+  * Summary text for this blame.
+  */
   summary: string;
-  lines?: number[]; // blame only
 }
 
-export interface GitMerge extends GitBlame {
+/**
+* A single commit & single file's parsed Git Blame
+*/
+export interface GitBlame extends GitBlameBase {
+  /**
+  * Timezone of author date
+  */
+  authorTz?: number;
+  /**
+  * Timezone of committer date
+  */
+  committerTz?: number;
+  /**
+  * Lines of file this blame applies to
+  */
+  lines?: number[];
+}
+
+/**
+* Blame information for a git merge, typically parsed from Github format PR messages.
+*/
+export interface GitMerge extends GitBlameBase {
+  /**
+  * The parent commits for this merge
+  */
   parent: string[]; // merge commit
+  /**
+  * Pull request number, parsed from summary.
+  */
   pr?: number;
+  /**
+  * Branch name, parsed from summary.
+  */
   branch?: string;
 }


### PR DESCRIPTION
Add jsdoc comments to types & their fields. Create a new `GitBlameBase` that blame/merge both derive from.